### PR TITLE
Add only() method to the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ CountryColumn::make('country')
 
 ## Configuration
 
-On top of all **[Select Field](https://filamentphp.com/docs/3.x/forms/fields/select)** methods, you can use these three helpers for the Form Component.
+On top of all **[Select Field](https://filamentphp.com/docs/3.x/forms/fields/select)** methods, you can use these four helpers for the Form Component.
 
+- `only()` restricts the list of countries.
 - `exclude()` removes an item from the list.
 - `add()` adds your own value to the list.
 - `map()` changes one key to another, such as `GB` to `UK`.
@@ -55,6 +56,7 @@ On top of all **[Select Field](https://filamentphp.com/docs/3.x/forms/fields/sel
 use Parfaitementweb\FilamentCountryField\Forms\Components\Country;
 
 Country::make('country')
+->only(['GB', 'GF', 'NL'])
 ->exclude(['NL'])
 ->add(['MA' =>'Mars'])
 ->map(['GB' => 'UK', 'GF' => 'FR'])

--- a/src/Forms/Components/Country.php
+++ b/src/Forms/Components/Country.php
@@ -17,6 +17,8 @@ class Country extends Select
 
     protected array | Arrayable | string | Closure | null $mapped = null;
 
+    protected array | Arrayable | string | Closure | null $only = null;
+
     public function getOptions(): array
     {
         $options = $this->evaluate($this->options) ?? [];
@@ -28,6 +30,19 @@ class Country extends Select
         $countries = $this->getCountriesList();
 
         return collect($countries)
+            ->when($this->only, function ($options) {
+                $onlyCountries = $this->getOnly();
+
+                if (empty($onlyCountries)) {
+                    return $options;
+                }
+
+                $filtered = $options->filter(function ($country, $key) use ($onlyCountries) {
+                    return in_array($key, $onlyCountries);
+                });
+
+                return $filtered->isEmpty() ? $options : $filtered;
+            })
             ->when($this->mapped, function ($options) {
                 return $options->mapWithKeys(function ($country, $key) {
                     if (in_array($key, array_keys($this->mapped))) {
@@ -44,6 +59,7 @@ class Country extends Select
             ->sort()
             ->toArray();
     }
+
 
     public function map(array | Closure | string | Arrayable | null $mapped = null): static
     {
@@ -79,5 +95,17 @@ class Country extends Select
     public function getAdd(): array
     {
         return $this->evaluate($this->added ?? []);
+    }
+
+    public function only(array | Closure | string | Arrayable | null $only = null): static
+    {
+        $this->only = $only;
+
+        return $this;
+    }
+
+    public function getOnly(): array
+    {
+        return $this->evaluate($this->only ?? []);
     }
 }

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -192,3 +192,91 @@ it('clears the countries cache', function () {
 
     expect(Cache::get('filament-countries-field.en'))->toBeNull();
 });
+
+it('can filter to only show specific countries', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium']);
+    });
+
+    $options = $mock
+        ->only(['US', 'CA'])
+        ->getOptions();
+
+    expect($options)->toBe(['CA' => 'Canada', 'US' => 'United States']);
+});
+
+it('shows all countries when only() is called with an empty array', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium']);
+    });
+
+    $options = $mock
+        ->only([])
+        ->getOptions();
+
+    expect($options)->toBe(['BE' => 'Belgium', 'CA' => 'Canada', 'US' => 'United States']);
+});
+
+it('shows all countries when only() is passed non-existent country codes', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium']);
+    });
+
+    $options = $mock
+        ->only(['XX', 'YY'])
+        ->getOptions();
+
+    expect($options)->toBe(['BE' => 'Belgium', 'CA' => 'Canada', 'US' => 'United States']);
+});
+
+it('correctly combines only() with exclude() to filter countries', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium', 'FR' => 'France']);
+    });
+
+    $options = $mock
+        ->only(['US', 'CA', 'BE'])
+        ->exclude(['BE'])
+        ->getOptions();
+
+    expect($options)->toBe(['CA' => 'Canada', 'US' => 'United States']);
+});
+
+it('returns filtered options after only(), exclude(), add() and map() operations', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium', 'FR' => 'France']);
+    });
+
+    $options = $mock
+        ->only(['US', 'CA', 'BE'])
+        ->exclude(['BE'])
+        ->add(['MA' => 'Mars'])
+        ->map(['US' => 'UN'])
+        ->getOptions();
+
+    expect($options)->toBe(['CA' => 'Canada', 'MA' => 'Mars', 'UN' => 'United States']);
+});
+
+it('can filter valid countries when only() contains a mix of valid and invalid codes', function () {
+    $mock = $this->partialMock(Country::class, function (MockInterface $mock) {
+        $mock->shouldReceive('getList')
+            ->once()
+            ->andReturn(['US' => 'United States', 'CA' => 'Canada', 'BE' => 'Belgium']);
+    });
+
+    $options = $mock
+        ->only(['US', 'XX'])
+        ->getOptions();
+
+    expect($options)->toBe(['US' => 'United States']);
+});


### PR DESCRIPTION
Hey 👋

Thank you for your plugin : it is very useful to me! 😇

I would like to propose a new method, `only()`, to provide an additional way to limit the list of countries when we do not wish to have too many options in the Select. This method can be utilised in addition to the others...

- Add `only()` method to filter and display specific countries by their code
- Ensure empty array for this method returns all countries 
- Handle invalid country codes
- Add test suite for the new feature
- Modify the readme with the new method
